### PR TITLE
[BUGFIX] Change argument name to the correct variable name

### DIFF
--- a/Resources/Private/Partials/Company/Properties.html
+++ b/Resources/Private/Partials/Company/Properties.html
@@ -63,7 +63,7 @@
 											 extensionName="maps2"
 											 pluginName="maps2"
 											 pageUid="{settings.pidOfMaps2Plugin}"
-											 arguments="{poiCollection: company.txMaps2Uid}">
+											 arguments="{poiCollectionUid: company.txMaps2Uid}">
 					<f:image class="floatright"
 									 src="EXT:yellowpages2/Resources/Public/Icons/ThumbMaps2.png"
 									 alt="{f:translate(key: 'altTextMapImg')}" />


### PR DESCRIPTION
In maps2 the variable name in the controller action "show" is "poiCollectionUid".