### PR TITLE
Order the categories after their title.

### DIFF
--- a/Classes/Domain/Repository/CategoryRepository.php
+++ b/Classes/Domain/Repository/CategoryRepository.php
@@ -91,7 +91,8 @@ class CategoryRepository extends Repository
                 $queryBuilder->expr()->isNotNull(
                     'c.uid'
                 )
-            );
+            )
+            ->orderBy('title');
 
         return $query->statement($queryBuilder)->execute();
     }


### PR DESCRIPTION
Get the categories in the select box in the search partial alphabetically ordered, after their title.